### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs
+      - id: deploy
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Welcome to Flags of the World, a community-maintained showcase of national flags
 The goal is to collect correct, scalable, and self-contained stylesheets for every sovereign nation’s flag.
 The goal being: Drop a `<div>` (i.e. `<div id="usa" />`) on the page, add a single class, and you’re flying colors.
 
-A live gallery of the completed flags is available on GitHub Pages from the `docs/` folder.
+A live gallery of the completed flags is automatically published to GitHub Pages from the `docs/` folder via GitHub Actions.


### PR DESCRIPTION
## Summary
- add workflow to automatically publish docs folder to GitHub Pages
- note in README that deployment is handled by GitHub Actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688bace0a4dc8328bbcb70f44951d427