### PR TITLE
Add script to generate README from completed flag styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,226 +1,108 @@
 # Flags of the World
 
 A showcase of national flags rendered with pure CSS.
-We aim to collect correct, scalable, and self-contained stylesheets for each polity 
-that can be used as a single self-contained div (i.e. `<div id="usa" />`).
 
-A [gallery of the completed flags](https://seanwevans.github.io/flags-of-the-world/)
-
-# Guidelines
-
-* wikipedia is the default source for flag specifications.
-* simpler representations favored over more complex.
-* SVG is a last resort.
-  
-# UN Member States
-
-Below is a list of all **193** United Nations member countries
+Currently, **100** flags are included.
 
 ## Completed
 
-* [🇩🇿 Algeria](https://en.wikipedia.org/wiki/Flag_of_Algeria)
-* [🇦🇲 Armenia](https://en.wikipedia.org/wiki/Flag_of_Armenia)
-* [🇦🇹 Austria](https://en.wikipedia.org/wiki/Flag_of_Austria)
-* [🇧🇩 Bangladesh](https://en.wikipedia.org/wiki/Flag_of_Bangladesh)
-* [🇧🇪 Belgium](https://en.wikipedia.org/wiki/Flag_of_Belgium)
-* [🇧🇯 Benin](https://en.wikipedia.org/wiki/Flag_of_Benin)
-* [🇧🇴 Bolivia](https://en.wikipedia.org/wiki/Flag_of_Bolivia)
-* [🇧🇼 Botswana](https://en.wikipedia.org/wiki/Flag_of_Botswana)
-* [🇧🇬 Bulgaria](https://en.wikipedia.org/wiki/Flag_of_Bulgaria)
-* [🇧🇫 Burkina Faso](https://en.wikipedia.org/wiki/Flag_of_Burkina_Faso)
-* [🇨🇲 Cameroon](https://en.wikipedia.org/wiki/Flag_of_Cameroon)
-* [🇹🇩 Chad](https://en.wikipedia.org/wiki/Flag_of_Chad)
-* [🇨🇱 Chile](https://en.wikipedia.org/wiki/Flag_of_Chile)
-* [🇨🇳 China](https://en.wikipedia.org/wiki/Flag_of_China)
-* [🇨🇴 Colombia](https://en.wikipedia.org/wiki/Flag_of_Colombia)
-* [🇨🇮 Côte d’Ivoire](https://en.wikipedia.org/wiki/Flag_of_Ivory_Coast)
-* [🇨🇿 Czech Republic](https://en.wikipedia.org/wiki/Flag_of_the_Czech_Republic)
-* [🇨🇩 Democratic Republic of the Congo](https://en.wikipedia.org/wiki/Flag_of_the_Democratic_Republic_of_the_Congo)
-* [🇩🇰 Denmark](https://en.wikipedia.org/wiki/Flag_of_Denmark)
-* [🇩🇯 Djibouti](https://en.wikipedia.org/wiki/Flag_of_Djibouti)
-* [🇪🇪 Estonia](https://en.wikipedia.org/wiki/Flag_of_Estonia)
-* [🇪🇬 Egypt](https://en.wikipedia.org/wiki/Flag_of_Egypt)
-* [🇫🇮 Finland](https://en.wikipedia.org/wiki/Flag_of_Finland)
-* [🇫🇷 France](https://en.wikipedia.org/wiki/Flag_of_France)
-* [🇬🇦 Gabon](https://en.wikipedia.org/wiki/Flag_of_Gabon)
-* [🇬🇲 Gambia](https://en.wikipedia.org/wiki/Flag_of_The_Gambia)
-* [🇬🇭 Ghana](https://en.wikipedia.org/wiki/Flag_of_Ghana)
-* [🇩🇪 Germany](https://en.wikipedia.org/wiki/Flag_of_Germany)
-* [🇬🇳 Guinea](https://en.wikipedia.org/wiki/Flag_of_Guinea)
-* [🇭🇳 Honduras](https://en.wikipedia.org/wiki/Flag_of_Honduras)
-* [🇭🇺 Hungary](https://en.wikipedia.org/wiki/Flag_of_Hungary)
-* [🇮🇸 Iceland](https://en.wikipedia.org/wiki/Flag_of_Iceland)
-* [🇮🇳 India](https://en.wikipedia.org/wiki/Flag_of_India)
-* [🇮🇩 Indonesia](https://en.wikipedia.org/wiki/Flag_of_Indonesia)
-* [🇮🇪 Ireland](https://en.wikipedia.org/wiki/Flag_of_Ireland)
-* [🇮🇹 Italy](https://en.wikipedia.org/wiki/Flag_of_Italy)
-* [🇯🇲 Jamaica](https://en.wikipedia.org/wiki/Flag_of_Jamaica)
-* [🇯🇵 Japan](https://en.wikipedia.org/wiki/Flag_of_Japan)
-* [🇯🇴 Jordan](https://en.wikipedia.org/wiki/Flag_of_Jordan)
-* [🇰🇼 Kuwait](https://en.wikipedia.org/wiki/Flag_of_Kuwait)
-* [🇱🇦 Laos](https://en.wikipedia.org/wiki/Flag_of_Laos)
-* [🇱🇻 Latvia](https://en.wikipedia.org/wiki/Flag_of_Latvia)
-* [🇱🇹 Lithuania](https://en.wikipedia.org/wiki/Flag_of_Lithuania)
-* [🇱🇺 Luxembourg](https://en.wikipedia.org/wiki/Flag_of_Luxembourg)
-* [🇲🇬 Madagascar](https://en.wikipedia.org/wiki/Flag_of_Madagascar)
-* [🇲🇱 Mali](https://en.wikipedia.org/wiki/Flag_of_Mali)
-* [🇲🇨 Monaco](https://en.wikipedia.org/wiki/Flag_of_Monaco)
-* [🇲🇦 Morocco](https://en.wikipedia.org/wiki/Flag_of_Morocco)
-* [🇳🇱 Netherlands](https://en.wikipedia.org/wiki/Flag_of_the_Netherlands)
-* [🇳🇪 Niger](https://en.wikipedia.org/wiki/Flag_of_Niger)
-* [🇳🇬 Nigeria](https://en.wikipedia.org/wiki/Flag_of_Nigeria)
-* [🇳🇴 Norway](https://en.wikipedia.org/wiki/Flag_of_Norway)
-* [🇵🇼 Palau](https://en.wikipedia.org/wiki/Flag_of_Palau)
-* [🇵🇱 Poland](https://en.wikipedia.org/wiki/Flag_of_Poland)
-* [🇶🇦 Qatar](https://en.wikipedia.org/wiki/Flag_of_Qatar)
-* [🇨🇬 Republic of the Congo](https://en.wikipedia.org/wiki/Flag_of_the_Republic_of_the_Congo)
-* [🇷🇴 Romania](https://en.wikipedia.org/wiki/Flag_of_Romania)
-* [🇷🇺 Russia](https://send.monobank.ua/jar/E5kHzqvBb)
-* [🇷🇼 Rwanda](https://en.wikipedia.org/wiki/Flag_of_Rwanda)
-* [🇸🇳 Senegal](https://en.wikipedia.org/wiki/Flag_of_Senegal)
-* [🇸🇱 Sierra Leone](https://en.wikipedia.org/wiki/Flag_of_Sierra_Leone)
-* [🇸🇴 Somalia](https://en.wikipedia.org/wiki/Flag_of_Somalia)
-* [🇸🇪 Sweden](https://en.wikipedia.org/wiki/Flag_of_Sweden)
-* [🇨🇭 Switzerland](https://en.wikipedia.org/wiki/Flag_of_Switzerland)
-* [🇹🇭 Thailand](https://en.wikipedia.org/wiki/Flag_of_Thailand)
-* [🇹🇳 Tunisia](https://en.wikipedia.org/wiki/Flag_of_Tunisia)
-* [🇺🇦 Ukraine](https://en.wikipedia.org/wiki/Flag_of_Ukraine)
-* [🇺🇸 United States](https://en.wikipedia.org/wiki/Flag_of_the_United_States)
-* [🇻🇳 Vietnam](https://en.wikipedia.org/wiki/Flag_of_Vietnam)  
-* [🇾🇪 Yemen](https://en.wikipedia.org/wiki/Flag_of_Yemen)
-
-## To do
-* 🇦🇫 Afghanistan
-* 🇦🇱 Albania
-* 🇦🇩 Andorra
-* 🇦🇴 Angola
-* 🇦🇬 Antigua and Barbuda
-* 🇦🇷 Argentina
-* 🇦🇺 Australia
-* 🇦🇿 Azerbaijan
-* 🇧🇸 Bahamas
-* 🇧🇭 Bahrain
-* 🇧🇧 Barbados
-* 🇧🇾 Belarus
-* 🇧🇿 Belize
-* 🇧🇯 Benin
-* 🇧🇹 Bhutan
-* 🇧🇴 Bolivia
-* 🇧🇦 Bosnia and Herzegovina
-* 🇧🇷 Brazil
-* 🇧🇳 Brunei
-* 🇧🇫 Burkina Faso
-* 🇧🇮 Burundi
-* 🇨🇻 Cabo Verde
-* 🇰🇭 Cambodia
-* 🇨🇦 Canada
-* 🇨🇫 Central African Republic
-* 🇰🇲 Comoros
-* 🇨🇷 Costa Rica
-* 🇭🇷 Croatia
-* 🇨🇺 Cuba
-* 🇨🇾 Cyprus
-* 🇩🇯 Djibouti
-* 🇩🇲 Dominica
-* 🇩🇴 Dominican Republic
-* 🇪🇨 Ecuador
-* 🇸🇻 El Salvador
-* 🇪🇷 Eritrea
-* 🇸🇿 Eswatini
-* 🇪🇹 Ethiopia
-* 🇫🇯 Fiji
-* 🇬🇪 Georgia
-* 🇬🇷 Greece
-* 🇬🇩 Grenada
-* 🇬🇹 Guatemala
-* 🇬🇾 Guyana
-* 🇭🇹 Haiti
-* 🇭🇳 Honduras
-* 🇮🇸 Iceland
-* 🇮🇳 India
-* 🇮🇷 Iran
-* 🇮🇶 Iraq
-* 🇮🇱 Israel
-* 🇯🇲 Jamaica
-* 🇯🇴 Jordan
-* 🇰🇿 Kazakhstan
-* 🇰🇪 Kenya
-* 🇰🇮 Kiribati
-* 🇰🇬 Kyrgyzstan
-* 🇱🇧 Lebanon
-* 🇱🇸 Lesotho
-* 🇱🇷 Liberia
-* 🇱🇾 Libya
-* 🇱🇮 Liechtenstein
-* 🇲🇼 Malawi
-* 🇲🇾 Malaysia
-* 🇲🇻 Maldives
-* 🇲🇹 Malta
-* 🇲🇭 Marshall Islands
-* 🇲🇷 Mauritania
-* 🇲🇺 Mauritius
-* 🇲🇽 Mexico
-* 🇫🇲 Micronesia
-* 🇲🇩 Moldova
-* 🇲🇳 Mongolia
-* 🇲🇪 Montenegro
-* 🇲🇿 Mozambique
-* 🇲🇲 Myanmar
-* 🇳🇦 Namibia
-* 🇳🇷 Nauru
-* 🇳🇵 Nepal
-* 🇳🇿 New Zealand
-* 🇳🇮 Nicaragua
-* 🇰🇵 North Korea
-* 🇲🇰 North Macedonia
-* 🇳🇴 Norway
-* 🇴🇲 Oman
-* 🇵🇰 Pakistan
-* 🇵🇦 Panama
-* 🇵🇾 Paraguay
-* 🇵🇪 Peru
-* 🇵🇭 Philippines
-* 🇵🇹 Portugal
-* 🇶🇦 Qatar
-* 🇷🇼 Rwanda
-* 🇰🇳 Saint Kitts and Nevis
-* 🇱🇨 Saint Lucia
-* 🇻🇨 Saint Vincent and the Grenadines
-* 🇼🇸 Samoa
-* 🇸🇲 San Marino
-* 🇸🇹 Sao Tome and Principe
-* 🇸🇦 Saudi Arabia
-* 🇷🇸 Serbia
-* 🇸🇨 Seychelles
-* 🇸🇬 Singapore
-* 🇸🇰 Slovakia
-* 🇸🇮 Slovenia
-* 🇸🇧 Solomon Islands
-* 🇿🇦 South Africa
-* 🇰🇷 South Korea
-* 🇸🇸 South Sudan
-* 🇪🇸 Spain
-* 🇱🇰 Sri Lanka
-* 🇸🇩 Sudan
-* 🇸🇷 Suriname
-* 🇨🇭 Switzerland
-* 🇸🇾 Syria
-* 🇹🇯 Tajikistan
-* 🇹🇿 Tanzania
-* 🇹🇱 Timor‑Leste
-* 🇹🇬 Togo
-* 🇹🇴 Tonga
-* 🇹🇹 Trinidad and Tobago
-* 🇹🇳 Tunisia
-* 🇹🇷 Turkey
-* 🇹🇲 Turkmenistan
-* 🇹🇻 Tuvalu
-* 🇺🇬 Uganda
-* 🇦🇪 United Arab Emirates
-* 🇬🇧 United Kingdom
-* 🇺🇾 Uruguay
-* 🇺🇿 Uzbekistan
-* 🇻🇺 Vanuatu
-* 🇻🇪 Venezuela
-* 🇿🇲 Zambia
-* 🇿🇼 Zimbabwe
+* [Algeria](https://en.wikipedia.org/wiki/Flag_of_Algeria)
+* [Argentina](https://en.wikipedia.org/wiki/Flag_of_Argentina)
+* [Armenia](https://en.wikipedia.org/wiki/Flag_of_Armenia)
+* [Austria](https://en.wikipedia.org/wiki/Flag_of_Austria)
+* [Bahamas](https://en.wikipedia.org/wiki/Flag_of_Bahamas)
+* [Bahrain](https://en.wikipedia.org/wiki/Flag_of_Bahrain)
+* [Bangladesh](https://en.wikipedia.org/wiki/Flag_of_Bangladesh)
+* [Belgium](https://en.wikipedia.org/wiki/Flag_of_Belgium)
+* [Benin](https://en.wikipedia.org/wiki/Flag_of_Benin)
+* [Bolivia](https://en.wikipedia.org/wiki/Flag_of_Bolivia)
+* [Botswana](https://en.wikipedia.org/wiki/Flag_of_Botswana)
+* [Bulgaria](https://en.wikipedia.org/wiki/Flag_of_Bulgaria)
+* [Burkina Faso](https://en.wikipedia.org/wiki/Flag_of_Burkina_Faso)
+* [Cameroon](https://en.wikipedia.org/wiki/Flag_of_Cameroon)
+* [Canada](https://en.wikipedia.org/wiki/Flag_of_Canada)
+* [Chad](https://en.wikipedia.org/wiki/Flag_of_Chad)
+* [Chile](https://en.wikipedia.org/wiki/Flag_of_Chile)
+* [China](https://en.wikipedia.org/wiki/Flag_of_China)
+* [Colombia](https://en.wikipedia.org/wiki/Flag_of_Colombia)
+* [Democratic Republic of the Congo](https://en.wikipedia.org/wiki/Flag_of_Democratic_Republic_of_the_Congo)
+* [Republic of the Congo](https://en.wikipedia.org/wiki/Flag_of_Republic_of_the_Congo)
+* [Cuba](https://en.wikipedia.org/wiki/Flag_of_Cuba)
+* [Czech Republic](https://en.wikipedia.org/wiki/Flag_of_Czech_Republic)
+* [Denmark](https://en.wikipedia.org/wiki/Flag_of_Denmark)
+* [Djibouti](https://en.wikipedia.org/wiki/Flag_of_Djibouti)
+* [Egypt](https://en.wikipedia.org/wiki/Flag_of_Egypt)
+* [England](https://en.wikipedia.org/wiki/Flag_of_England)
+* [Estonia](https://en.wikipedia.org/wiki/Flag_of_Estonia)
+* [Finland](https://en.wikipedia.org/wiki/Flag_of_Finland)
+* [France](https://en.wikipedia.org/wiki/Flag_of_France)
+* [Gabon](https://en.wikipedia.org/wiki/Flag_of_Gabon)
+* [Gambia](https://en.wikipedia.org/wiki/Flag_of_Gambia)
+* [Germany](https://en.wikipedia.org/wiki/Flag_of_Germany)
+* [Ghana](https://en.wikipedia.org/wiki/Flag_of_Ghana)
+* [Greece](https://en.wikipedia.org/wiki/Flag_of_Greece)
+* [Guinea](https://en.wikipedia.org/wiki/Flag_of_Guinea)
+* [Honduras](https://en.wikipedia.org/wiki/Flag_of_Honduras)
+* [Hungary](https://en.wikipedia.org/wiki/Flag_of_Hungary)
+* [Iceland](https://en.wikipedia.org/wiki/Flag_of_Iceland)
+* [India](https://en.wikipedia.org/wiki/Flag_of_India)
+* [Indonesia](https://en.wikipedia.org/wiki/Flag_of_Indonesia)
+* [Ireland](https://en.wikipedia.org/wiki/Flag_of_Ireland)
+* [Italy](https://en.wikipedia.org/wiki/Flag_of_Italy)
+* [Ivory Coast](https://en.wikipedia.org/wiki/Flag_of_Ivory_Coast)
+* [Jamaica](https://en.wikipedia.org/wiki/Flag_of_Jamaica)
+* [Japan](https://en.wikipedia.org/wiki/Flag_of_Japan)
+* [Jordan](https://en.wikipedia.org/wiki/Flag_of_Jordan)
+* [Kuwait](https://en.wikipedia.org/wiki/Flag_of_Kuwait)
+* [Laos](https://en.wikipedia.org/wiki/Flag_of_Laos)
+* [Latvia](https://en.wikipedia.org/wiki/Flag_of_Latvia)
+* [Liberia](https://en.wikipedia.org/wiki/Flag_of_Liberia)
+* [Libya](https://en.wikipedia.org/wiki/Flag_of_Libya)
+* [Lithuania](https://en.wikipedia.org/wiki/Flag_of_Lithuania)
+* [Luxembourg](https://en.wikipedia.org/wiki/Flag_of_Luxembourg)
+* [Madagascar](https://en.wikipedia.org/wiki/Flag_of_Madagascar)
+* [Mali](https://en.wikipedia.org/wiki/Flag_of_Mali)
+* [Mauritius](https://en.wikipedia.org/wiki/Flag_of_Mauritius)
+* [Mexico](https://en.wikipedia.org/wiki/Flag_of_Mexico)
+* [Monaco](https://en.wikipedia.org/wiki/Flag_of_Monaco)
+* [Morocco](https://en.wikipedia.org/wiki/Flag_of_Morocco)
+* [Myanmar](https://en.wikipedia.org/wiki/Flag_of_Myanmar)
+* [Nauru](https://en.wikipedia.org/wiki/Flag_of_Nauru)
+* [Netherlands](https://en.wikipedia.org/wiki/Flag_of_Netherlands)
+* [Niger](https://en.wikipedia.org/wiki/Flag_of_Niger)
+* [Nigeria](https://en.wikipedia.org/wiki/Flag_of_Nigeria)
+* [Norway](https://en.wikipedia.org/wiki/Flag_of_Norway)
+* [Pakistan](https://en.wikipedia.org/wiki/Flag_of_Pakistan)
+* [Palau](https://en.wikipedia.org/wiki/Flag_of_Palau)
+* [Panama](https://en.wikipedia.org/wiki/Flag_of_Panama)
+* [Peru](https://en.wikipedia.org/wiki/Flag_of_Peru)
+* [Poland](https://en.wikipedia.org/wiki/Flag_of_Poland)
+* [Portugal](https://en.wikipedia.org/wiki/Flag_of_Portugal)
+* [Qatar](https://en.wikipedia.org/wiki/Flag_of_Qatar)
+* [Romania](https://en.wikipedia.org/wiki/Flag_of_Romania)
+* [Russia](https://en.wikipedia.org/wiki/Flag_of_Russia)
+* [Rwanda](https://en.wikipedia.org/wiki/Flag_of_Rwanda)
+* [Scotland](https://en.wikipedia.org/wiki/Flag_of_Scotland)
+* [Senegal](https://en.wikipedia.org/wiki/Flag_of_Senegal)
+* [Seychelles](https://en.wikipedia.org/wiki/Flag_of_Seychelles)
+* [Sierra Leone](https://en.wikipedia.org/wiki/Flag_of_Sierra_Leone)
+* [Somalia](https://en.wikipedia.org/wiki/Flag_of_Somalia)
+* [Spain](https://en.wikipedia.org/wiki/Flag_of_Spain)
+* [Sudan](https://en.wikipedia.org/wiki/Flag_of_Sudan)
+* [Suriname](https://en.wikipedia.org/wiki/Flag_of_Suriname)
+* [Sweden](https://en.wikipedia.org/wiki/Flag_of_Sweden)
+* [Switzerland](https://en.wikipedia.org/wiki/Flag_of_Switzerland)
+* [Syria](https://en.wikipedia.org/wiki/Flag_of_Syria)
+* [Tanzania](https://en.wikipedia.org/wiki/Flag_of_Tanzania)
+* [Thailand](https://en.wikipedia.org/wiki/Flag_of_Thailand)
+* [Togo](https://en.wikipedia.org/wiki/Flag_of_Togo)
+* [Tonga](https://en.wikipedia.org/wiki/Flag_of_Tonga)
+* [Trinidad and Tobago](https://en.wikipedia.org/wiki/Flag_of_Trinidad_and_Tobago)
+* [Tunisia](https://en.wikipedia.org/wiki/Flag_of_Tunisia)
+* [Turkey](https://en.wikipedia.org/wiki/Flag_of_Turkey)
+* [Ukraine](https://en.wikipedia.org/wiki/Flag_of_Ukraine)
+* [United Arab Emirates](https://en.wikipedia.org/wiki/Flag_of_United_Arab_Emirates)
+* [United States](https://en.wikipedia.org/wiki/Flag_of_United_States)
+* [Uzbekistan](https://en.wikipedia.org/wiki/Flag_of_Uzbekistan)
+* [Vietnam](https://en.wikipedia.org/wiki/Flag_of_Vietnam)
+* [Yemen](https://en.wikipedia.org/wiki/Flag_of_Yemen)

--- a/generate_readme.py
+++ b/generate_readme.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import sys
+
+# Mapping for filenames that don't convert cleanly to country names
+SPECIAL_NAMES = {
+    "usa": "United States",
+    "czech-republic": "Czech Republic",
+    "congo-drc": "Democratic Republic of the Congo",
+    "congo-republic": "Republic of the Congo",
+    "ivory-coast": "Ivory Coast",
+    "trinidad-and-tobago": "Trinidad and Tobago",
+    "united-arab-emirates": "United Arab Emirates",
+}
+
+
+def format_name(file_stem: str) -> str:
+    """Convert a CSS filename stem into a human-friendly country name."""
+    if file_stem in SPECIAL_NAMES:
+        return SPECIAL_NAMES[file_stem]
+    words = file_stem.replace('_', '-').split('-')
+    return " ".join(word.capitalize() for word in words)
+
+
+def main(output_path: str = "README.md") -> None:
+    css_files = sorted(Path(".").glob("*.css"))
+    countries = [format_name(f.stem) for f in css_files]
+
+    lines = [
+        "# Flags of the World",
+        "",
+        "A showcase of national flags rendered with pure CSS.",
+        "",
+        f"Currently, **{len(countries)}** flags are included.",
+        "",
+        "## Completed",
+        "",
+    ]
+    for name in countries:
+        wiki_name = name.replace(" ", "_")
+        lines.append(f"* [{name}](https://en.wikipedia.org/wiki/Flag_of_{wiki_name})")
+    lines.append("")
+    Path(output_path).write_text("\n".join(lines), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    out = sys.argv[1] if len(sys.argv) > 1 else "README.md"
+    main(out)


### PR DESCRIPTION
## Summary
- add `generate_readme.py` to scan CSS files and build the README with country links
- regenerate README listing the 100 available flag styles

## Testing
- `python generate_readme.py`


------
https://chatgpt.com/codex/tasks/task_e_68954cf7247483288fe740b1eb758614