### PR TITLE
Sort flags alphabetically on GitHub page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,141 +3,203 @@
 <head>
   <meta charset="UTF-8">
   <title>Flags of the World</title>
-  <link rel="stylesheet" href="algeria.css">
-  <link rel="stylesheet" href="armenia.css">
-  <link rel="stylesheet" href="austria.css">
-  <link rel="stylesheet" href="belgium.css">
-  <link rel="stylesheet" href="bulgaria.css">
-  <link rel="stylesheet" href="chad.css">
-  <link rel="stylesheet" href="colombia.css">
-  <link rel="stylesheet" href="estonia.css">
-  <link rel="stylesheet" href="france.css">
-  <link rel="stylesheet" href="germany.css">
-  <link rel="stylesheet" href="guinea.css">
-  <link rel="stylesheet" href="hungary.css">
-  <link rel="stylesheet" href="indonesia.css">
-  <link rel="stylesheet" href="ireland.css">
-  <link rel="stylesheet" href="italy.css">
-  <link rel="stylesheet" href="ivory-coast.css">
-  <link rel="stylesheet" href="japan.css">
-  <link rel="stylesheet" href="lithuania.css">
-  <link rel="stylesheet" href="luxembourg.css">
-  <link rel="stylesheet" href="mali.css">
-  <link rel="stylesheet" href="monaco.css">
-  <link rel="stylesheet" href="morocco.css">
-  <link rel="stylesheet" href="netherlands.css">
-  <link rel="stylesheet" href="nigeria.css">
-  <link rel="stylesheet" href="poland.css">
-  <link rel="stylesheet" href="romania.css">
-  <link rel="stylesheet" href="russia.css">
-  <link rel="stylesheet" href="ukraine.css">
-  <link rel="stylesheet" href="usa.css">
-  <link rel="stylesheet" href="bangladesh.css">
-  <link rel="stylesheet" href="botswana.css">
-  <link rel="stylesheet" href="cameroon.css">
-  <link rel="stylesheet" href="czech-republic.css">
-  <link rel="stylesheet" href="denmark.css">
-  <link rel="stylesheet" href="finland.css">
-  <link rel="stylesheet" href="gabon.css">
-  <link rel="stylesheet" href="gambia.css">
-  <link rel="stylesheet" href="ghana.css">
-  <link rel="stylesheet" href="kuwait.css">
-  <link rel="stylesheet" href="laos.css">
-  <link rel="stylesheet" href="latvia.css">
-  <link rel="stylesheet" href="madagascar.css">
-  <link rel="stylesheet" href="niger.css">
-  <link rel="stylesheet" href="palau.css">
-  <link rel="stylesheet" href="senegal.css">
-  <link rel="stylesheet" href="sierra-leone.css">
-  <link rel="stylesheet" href="somalia.css">
-  <link rel="stylesheet" href="sweden.css">
-  <link rel="stylesheet" href="yemen.css">
-  <link rel="stylesheet" href="benin.css">
-  <link rel="stylesheet" href="bolivia.css">
-  <link rel="stylesheet" href="burkina-faso.css">
-  <link rel="stylesheet" href="chile.css">
-  <link rel="stylesheet" href="china.css">
-  <link rel="stylesheet" href="congo-republic.css">
-  <link rel="stylesheet" href="congo-drc.css">
-  <link rel="stylesheet" href="djibouti.css">
-  <link rel="stylesheet" href="egypt.css">
-  <link rel="stylesheet" href="honduras.css">
-  <link rel="stylesheet" href="iceland.css">
-  <link rel="stylesheet" href="india.css">
-  <link rel="stylesheet" href="jamaica.css">
-  <link rel="stylesheet" href="jordan.css">
-  <link rel="stylesheet" href="norway.css">
-  <link rel="stylesheet" href="qatar.css">
-  <link rel="stylesheet" href="rwanda.css">
-  <link rel="stylesheet" href="switzerland.css">
-  <link rel="stylesheet" href="thailand.css">
-  <link rel="stylesheet" href="tunisia.css">
-  <link rel="stylesheet" href="vietnam.css">
-  <link rel="stylesheet" href="bahamas.css">
-  <link rel="stylesheet" href="bahrain.css">
-  <link rel="stylesheet" href="cuba.css">
-  <link rel="stylesheet" href="liberia.css">
-  <link rel="stylesheet" href="nauru.css">
-  <link rel="stylesheet" href="seychelles.css">
-  <link rel="stylesheet" href="tanzania.css">
-  <link rel="stylesheet" href="trinidad-and-tobago.css">
-  <link rel="stylesheet" href="suriname.css">
-  <link rel="stylesheet" href="syria.css">
-  <link rel="stylesheet" href="sudan.css">
-  <link rel="stylesheet" href="united-arab-emirates.css">
-  <link rel="stylesheet" href="libya.css">
-  <link rel="stylesheet" href="mauritius.css">
-  <link rel="stylesheet" href="pakistan.css">
-  <link rel="stylesheet" href="panama.css">
-  <link rel="stylesheet" href="togo.css">
-  <link rel="stylesheet" href="tonga.css">
-  <link rel="stylesheet" href="turkey.css">
-  <link rel="stylesheet" href="uzbekistan.css">
-  <link rel="stylesheet" href="argentina.css">
-  <link rel="stylesheet" href="canada.css">
-  <link rel="stylesheet" href="england.css">
-  <link rel="stylesheet" href="greece.css">
-  <link rel="stylesheet" href="mexico.css">
-  <link rel="stylesheet" href="myanmar.css">
-  <link rel="stylesheet" href="peru.css">
-  <link rel="stylesheet" href="portugal.css">
-  <link rel="stylesheet" href="scotland.css">
-  <link rel="stylesheet" href="spain.css">
-  <link rel="stylesheet" href="costa-rica.css">
-  <link rel="stylesheet" href="croatia.css">
-  <link rel="stylesheet" href="el-salvador.css">
-  <link rel="stylesheet" href="equatorial-guinea.css">
-  <link rel="stylesheet" href="guatemala.css">
-  <link rel="stylesheet" href="guinea-bissau.css">
-  <link rel="stylesheet" href="lesotho.css">
-  <link rel="stylesheet" href="moldova.css">
-  <link rel="stylesheet" href="nicaragua.css">
-  <link rel="stylesheet" href="paraguay.css">
   <link rel="stylesheet" href="afghanistan.css">
   <link rel="stylesheet" href="albania.css">
+  <link rel="stylesheet" href="algeria.css">
   <link rel="stylesheet" href="andorra.css">
   <link rel="stylesheet" href="angola.css">
+  <link rel="stylesheet" href="antigua-and-barbuda.css">
+  <link rel="stylesheet" href="argentina.css">
+  <link rel="stylesheet" href="armenia.css">
+  <link rel="stylesheet" href="australia.css">
+  <link rel="stylesheet" href="austria.css">
   <link rel="stylesheet" href="azerbaijan.css">
+  <link rel="stylesheet" href="bahamas.css">
+  <link rel="stylesheet" href="bahrain.css">
+  <link rel="stylesheet" href="bangladesh.css">
+  <link rel="stylesheet" href="barbados.css">
   <link rel="stylesheet" href="belarus.css">
+  <link rel="stylesheet" href="belgium.css">
+  <link rel="stylesheet" href="belize.css">
+  <link rel="stylesheet" href="benin.css">
+  <link rel="stylesheet" href="bhutan.css">
+  <link rel="stylesheet" href="bolivia.css">
+  <link rel="stylesheet" href="bosnia-and-herzegovina.css">
+  <link rel="stylesheet" href="botswana.css">
+  <link rel="stylesheet" href="brazil.css">
+  <link rel="stylesheet" href="brunei.css">
+  <link rel="stylesheet" href="bulgaria.css">
+  <link rel="stylesheet" href="burkina-faso.css">
+  <link rel="stylesheet" href="burundi.css">
   <link rel="stylesheet" href="cambodia.css">
+  <link rel="stylesheet" href="cameroon.css">
+  <link rel="stylesheet" href="canada.css">
   <link rel="stylesheet" href="cape-verde.css">
+  <link rel="stylesheet" href="central-african-republic.css">
+  <link rel="stylesheet" href="chad.css">
+  <link rel="stylesheet" href="chile.css">
+  <link rel="stylesheet" href="china.css">
+  <link rel="stylesheet" href="colombia.css">
   <link rel="stylesheet" href="comoros.css">
+  <link rel="stylesheet" href="congo-drc.css">
+  <link rel="stylesheet" href="congo-republic.css">
+  <link rel="stylesheet" href="costa-rica.css">
+  <link rel="stylesheet" href="croatia.css">
+  <link rel="stylesheet" href="cuba.css">
+  <link rel="stylesheet" href="cyprus.css">
+  <link rel="stylesheet" href="czech-republic.css">
+  <link rel="stylesheet" href="denmark.css">
+  <link rel="stylesheet" href="djibouti.css">
+  <link rel="stylesheet" href="dominica.css">
+  <link rel="stylesheet" href="dominican-republic.css">
+  <link rel="stylesheet" href="ecuador.css">
+  <link rel="stylesheet" href="egypt.css">
+  <link rel="stylesheet" href="el-salvador.css">
+  <link rel="stylesheet" href="england.css">
+  <link rel="stylesheet" href="equatorial-guinea.css">
+  <link rel="stylesheet" href="eritrea.css">
+  <link rel="stylesheet" href="estonia.css">
+  <link rel="stylesheet" href="eswatini.css">
   <link rel="stylesheet" href="ethiopia.css">
+  <link rel="stylesheet" href="fiji.css">
+  <link rel="stylesheet" href="finland.css">
+  <link rel="stylesheet" href="france.css">
+  <link rel="stylesheet" href="gabon.css">
+  <link rel="stylesheet" href="gambia.css">
   <link rel="stylesheet" href="georgia.css">
+  <link rel="stylesheet" href="germany.css">
+  <link rel="stylesheet" href="ghana.css">
+  <link rel="stylesheet" href="greece.css">
+  <link rel="stylesheet" href="grenada.css">
+  <link rel="stylesheet" href="guatemala.css">
+  <link rel="stylesheet" href="guinea.css">
+  <link rel="stylesheet" href="guinea-bissau.css">
+  <link rel="stylesheet" href="guyana.css">
+  <link rel="stylesheet" href="haiti.css">
+  <link rel="stylesheet" href="honduras.css">
+  <link rel="stylesheet" href="hungary.css">
+  <link rel="stylesheet" href="iceland.css">
+  <link rel="stylesheet" href="india.css">
+  <link rel="stylesheet" href="indonesia.css">
   <link rel="stylesheet" href="iran.css">
   <link rel="stylesheet" href="iraq.css">
+  <link rel="stylesheet" href="ireland.css">
   <link rel="stylesheet" href="israel.css">
+  <link rel="stylesheet" href="italy.css">
+  <link rel="stylesheet" href="ivory-coast.css">
+  <link rel="stylesheet" href="jamaica.css">
+  <link rel="stylesheet" href="japan.css">
+  <link rel="stylesheet" href="jordan.css">
+  <link rel="stylesheet" href="kazakhstan.css">
   <link rel="stylesheet" href="kenya.css">
-  <link rel="stylesheet" href="north-korea.css">
+  <link rel="stylesheet" href="kiribati.css">
+  <link rel="stylesheet" href="kuwait.css">
+  <link rel="stylesheet" href="kyrgyzstan.css">
+  <link rel="stylesheet" href="laos.css">
+  <link rel="stylesheet" href="latvia.css">
   <link rel="stylesheet" href="lebanon.css">
+  <link rel="stylesheet" href="lesotho.css">
+  <link rel="stylesheet" href="liberia.css">
+  <link rel="stylesheet" href="libya.css">
+  <link rel="stylesheet" href="liechtenstein.css">
+  <link rel="stylesheet" href="lithuania.css">
+  <link rel="stylesheet" href="luxembourg.css">
+  <link rel="stylesheet" href="madagascar.css">
   <link rel="stylesheet" href="malawi.css">
+  <link rel="stylesheet" href="malaysia.css">
   <link rel="stylesheet" href="maldives.css">
+  <link rel="stylesheet" href="mali.css">
+  <link rel="stylesheet" href="malta.css">
+  <link rel="stylesheet" href="marshall-islands.css">
+  <link rel="stylesheet" href="mauritania.css">
+  <link rel="stylesheet" href="mauritius.css">
+  <link rel="stylesheet" href="mexico.css">
+  <link rel="stylesheet" href="micronesia.css">
+  <link rel="stylesheet" href="moldova.css">
+  <link rel="stylesheet" href="monaco.css">
+  <link rel="stylesheet" href="mongolia.css">
+  <link rel="stylesheet" href="montenegro.css">
+  <link rel="stylesheet" href="morocco.css">
+  <link rel="stylesheet" href="mozambique.css">
+  <link rel="stylesheet" href="myanmar.css">
+  <link rel="stylesheet" href="namibia.css">
+  <link rel="stylesheet" href="nauru.css">
+  <link rel="stylesheet" href="nepal.css">
+  <link rel="stylesheet" href="netherlands.css">
+  <link rel="stylesheet" href="new-zealand.css">
+  <link rel="stylesheet" href="nicaragua.css">
+  <link rel="stylesheet" href="niger.css">
+  <link rel="stylesheet" href="nigeria.css">
+  <link rel="stylesheet" href="north-korea.css">
+  <link rel="stylesheet" href="north-macedonia.css">
+  <link rel="stylesheet" href="norway.css">
   <link rel="stylesheet" href="oman.css">
+  <link rel="stylesheet" href="pakistan.css">
+  <link rel="stylesheet" href="palau.css">
+  <link rel="stylesheet" href="palestine.css">
+  <link rel="stylesheet" href="panama.css">
+  <link rel="stylesheet" href="papua-new-guinea.css">
+  <link rel="stylesheet" href="paraguay.css">
+  <link rel="stylesheet" href="peru.css">
   <link rel="stylesheet" href="philippines.css">
+  <link rel="stylesheet" href="poland.css">
+  <link rel="stylesheet" href="portugal.css">
+  <link rel="stylesheet" href="qatar.css">
+  <link rel="stylesheet" href="romania.css">
+  <link rel="stylesheet" href="russia.css">
+  <link rel="stylesheet" href="rwanda.css">
+  <link rel="stylesheet" href="saint-kitts-and-nevis.css">
+  <link rel="stylesheet" href="saint-lucia.css">
+  <link rel="stylesheet" href="saint-vincent-and-the-grenadines.css">
+  <link rel="stylesheet" href="samoa.css">
+  <link rel="stylesheet" href="san-marino.css">
+  <link rel="stylesheet" href="sao-tome-and-principe.css">
+  <link rel="stylesheet" href="saudi-arabia.css">
+  <link rel="stylesheet" href="scotland.css">
+  <link rel="stylesheet" href="senegal.css">
+  <link rel="stylesheet" href="serbia.css">
+  <link rel="stylesheet" href="seychelles.css">
+  <link rel="stylesheet" href="sierra-leone.css">
   <link rel="stylesheet" href="singapore.css">
+  <link rel="stylesheet" href="slovakia.css">
   <link rel="stylesheet" href="slovenia.css">
+  <link rel="stylesheet" href="solomon-islands.css">
+  <link rel="stylesheet" href="somalia.css">
+  <link rel="stylesheet" href="south-africa.css">
+  <link rel="stylesheet" href="south-korea.css">
+  <link rel="stylesheet" href="south-sudan.css">
+  <link rel="stylesheet" href="spain.css">
+  <link rel="stylesheet" href="sri-lanka.css">
+  <link rel="stylesheet" href="sudan.css">
+  <link rel="stylesheet" href="suriname.css">
+  <link rel="stylesheet" href="sweden.css">
+  <link rel="stylesheet" href="switzerland.css">
+  <link rel="stylesheet" href="syria.css">
   <link rel="stylesheet" href="taiwan.css">
   <link rel="stylesheet" href="tajikistan.css">
+  <link rel="stylesheet" href="tanzania.css">
+  <link rel="stylesheet" href="thailand.css">
+  <link rel="stylesheet" href="timor-leste.css">
+  <link rel="stylesheet" href="togo.css">
+  <link rel="stylesheet" href="tonga.css">
+  <link rel="stylesheet" href="trinidad-and-tobago.css">
+  <link rel="stylesheet" href="tunisia.css">
+  <link rel="stylesheet" href="turkey.css">
+  <link rel="stylesheet" href="turkmenistan.css">
+  <link rel="stylesheet" href="tuvalu.css">
+  <link rel="stylesheet" href="uganda.css">
+  <link rel="stylesheet" href="ukraine.css">
+  <link rel="stylesheet" href="united-arab-emirates.css">
+  <link rel="stylesheet" href="united-kingdom.css">
+  <link rel="stylesheet" href="uruguay.css">
+  <link rel="stylesheet" href="usa.css">
+  <link rel="stylesheet" href="uzbekistan.css">
+  <link rel="stylesheet" href="vanuatu.css">
+  <link rel="stylesheet" href="venezuela.css">
+  <link rel="stylesheet" href="vietnam.css">
+  <link rel="stylesheet" href="yemen.css">
+  <link rel="stylesheet" href="zambia.css">
+  <link rel="stylesheet" href="zimbabwe.css">
   <style>
     body {
       font-family: sans-serif;
@@ -155,581 +217,12 @@
       border: 1px solid black;
     }
   </style>
-  <link rel="stylesheet" href="barbados.css">
-  <link rel="stylesheet" href="brazil.css">
-  <link rel="stylesheet" href="brunei.css">
-  <link rel="stylesheet" href="burundi.css">
-  <link rel="stylesheet" href="central-african-republic.css">
-  <link rel="stylesheet" href="dominican-republic.css">
-  <link rel="stylesheet" href="ecuador.css">
-  <link rel="stylesheet" href="eritrea.css">
-  <link rel="stylesheet" href="haiti.css">
-  <link rel="stylesheet" href="kazakhstan.css">
-  <link rel="stylesheet" href="kyrgyzstan.css">
-  <link rel="stylesheet" href="liechtenstein.css">
-  <link rel="stylesheet" href="mongolia.css">
-  <link rel="stylesheet" href="montenegro.css">
-  <link rel="stylesheet" href="namibia.css">
-  <link rel="stylesheet" href="nepal.css">
-  <link rel="stylesheet" href="new-zealand.css">
-  <link rel="stylesheet" href="palestine.css">
-  <link rel="stylesheet" href="micronesia.css">
-  <link rel="stylesheet" href="marshall-islands.css">
-  <link rel="stylesheet" href="san-marino.css">
-  <link rel="stylesheet" href="serbia.css">
-  <link rel="stylesheet" href="slovakia.css">
-  <link rel="stylesheet" href="zimbabwe.css">
-  <link rel="stylesheet" href="united-kingdom.css">
-  <link rel="stylesheet" href="vanuatu.css">
-  <link rel="stylesheet" href="solomon-islands.css">
-  <link rel="stylesheet" href="antigua-and-barbuda.css">
-  <link rel="stylesheet" href="turkmenistan.css">
-  <link rel="stylesheet" href="bosnia-and-herzegovina.css">
-  <link rel="stylesheet" href="mozambique.css">
-  <link rel="stylesheet" href="dominica.css">
-  <link rel="stylesheet" href="cyprus.css">
-  <link rel="stylesheet" href="kiribati.css">
-  <link rel="stylesheet" href="sri-lanka.css">
-  <link rel="stylesheet" href="timor-leste.css">
-  <link rel="stylesheet" href="eswatini.css">
-  <link rel="stylesheet" href="malaysia.css">
-  <link rel="stylesheet" href="tuvalu.css">
-  <link rel="stylesheet" href="south-africa.css">
-  <link rel="stylesheet" href="australia.css">
-  <link rel="stylesheet" href="saint-kitts-and-nevis.css">
-  <link rel="stylesheet" href="guyana.css">
-  <link rel="stylesheet" href="venezuela.css">
-  <link rel="stylesheet" href="bhutan.css">
-  <link rel="stylesheet" href="saudi-arabia.css">
-  <link rel="stylesheet" href="zambia.css">
-  <link rel="stylesheet" href="uruguay.css">
-  <link rel="stylesheet" href="fiji.css">
-  <link rel="stylesheet" href="sao-tome-and-principe.css">
-  <link rel="stylesheet" href="malta.css">
-  <link rel="stylesheet" href="mauritania.css">
-  <link rel="stylesheet" href="north-macedonia.css">
-  <link rel="stylesheet" href="south-sudan.css">
-  <link rel="stylesheet" href="grenada.css">
-  <link rel="stylesheet" href="papua-new-guinea.css">
-  <link rel="stylesheet" href="south-korea.css">
-  <link rel="stylesheet" href="belize.css">
-  <link rel="stylesheet" href="uganda.css">
-  <link rel="stylesheet" href="samoa.css">
 </head>
 
 <body>
 
 <section id="flags">
 
-  <figure class="flag-card">
-    <div id="algeria"></div>
-    <figcaption>Algeria</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="armenia"></div>
-    <figcaption>Armenia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="austria"></div>
-    <figcaption>Austria</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="belgium"></div>
-    <figcaption>Belgium</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="bulgaria"></div>
-    <figcaption>Bulgaria</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="chad"></div>
-    <figcaption>Chad</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="colombia"></div>
-    <figcaption>Colombia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="estonia"></div>
-    <figcaption>Estonia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="france"></div>
-    <figcaption>France</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="germany"></div>
-    <figcaption>Germany</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="guinea"></div>
-    <figcaption>Guinea</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="hungary"></div>
-    <figcaption>Hungary</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="indonesia"></div>
-    <figcaption>Indonesia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="ireland"></div>
-    <figcaption>Ireland</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="italy"></div>
-    <figcaption>Italy</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="ivory-coast"></div>
-    <figcaption>Ivory Coast</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="japan"></div>
-    <figcaption>Japan</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="lithuania"></div>
-    <figcaption>Lithuania</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="luxembourg"></div>
-    <figcaption>Luxembourg</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="mali"></div>
-    <figcaption>Mali</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="monaco"></div>
-    <figcaption>Monaco</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="morocco"></div>
-    <figcaption>Morocco</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="netherlands"></div>
-    <figcaption>Netherlands</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="nigeria"></div>
-    <figcaption>Nigeria</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="poland"></div>
-    <figcaption>Poland</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="romania"></div>
-    <figcaption>Romania</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="russia"></div>
-    <figcaption>Russia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="ukraine"></div>
-    <figcaption>Ukraine</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="usa"></div>
-    <figcaption>United States of America</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="bangladesh"></div>
-    <figcaption>Bangladesh</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="botswana"></div>
-    <figcaption>Botswana</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="cameroon"></div>
-    <figcaption>Cameroon</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="czech-republic"></div>
-    <figcaption>Czech Republic</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="denmark"></div>
-    <figcaption>Denmark</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="finland"></div>
-    <figcaption>Finland</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="gabon"></div>
-    <figcaption>Gabon</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="gambia"></div>
-    <figcaption>Gambia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="ghana"></div>
-    <figcaption>Ghana</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="kuwait"></div>
-    <figcaption>Kuwait</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="laos"></div>
-    <figcaption>Laos</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="latvia"></div>
-    <figcaption>Latvia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="madagascar"></div>
-    <figcaption>Madagascar</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="niger"></div>
-    <figcaption>Niger</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="palau"></div>
-    <figcaption>Palau</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="senegal"></div>
-    <figcaption>Senegal</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="sierra-leone"></div>
-    <figcaption>Sierra Leone</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="somalia"></div>
-    <figcaption>Somalia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="sweden"></div>
-    <figcaption>Sweden</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="yemen"></div>
-    <figcaption>Yemen</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="benin"></div>
-    <figcaption>Benin</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="bolivia"></div>
-    <figcaption>Bolivia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="burkina-faso"></div>
-    <figcaption>Burkina Faso</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="chile"></div>
-    <figcaption>Chile</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="china"></div>
-    <figcaption>China</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="congo-republic"></div>
-    <figcaption>Republic of the Congo</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="congo-drc"></div>
-    <figcaption>Democratic Republic of the Congo</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="djibouti"></div>
-    <figcaption>Djibouti</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="egypt"></div>
-    <figcaption>Egypt</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="honduras"></div>
-    <figcaption>Honduras</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="iceland"></div>
-    <figcaption>Iceland</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="india"></div>
-    <figcaption>India</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="jamaica"></div>
-    <figcaption>Jamaica</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="jordan"></div>
-    <figcaption>Jordan</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="norway"></div>
-    <figcaption>Norway</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="qatar"></div>
-    <figcaption>Qatar</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="rwanda"></div>
-    <figcaption>Rwanda</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="switzerland"></div>
-    <figcaption>Switzerland</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="thailand"></div>
-    <figcaption>Thailand</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="tunisia"></div>
-    <figcaption>Tunisia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="vietnam"></div>
-    <figcaption>Vietnam</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="bahamas"></div>
-    <figcaption>Bahamas</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="bahrain"></div>
-    <figcaption>Bahrain</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="cuba"></div>
-    <figcaption>Cuba</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="liberia"></div>
-    <figcaption>Liberia</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="nauru"></div>
-    <figcaption>Nauru</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="seychelles"></div>
-    <figcaption>Seychelles</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="tanzania"></div>
-    <figcaption>Tanzania</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="trinidad-and-tobago"></div>
-    <figcaption>Trinidad and Tobago</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="suriname"></div>
-    <figcaption>Suriname</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="syria"></div>
-    <figcaption>Syria</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="sudan"></div>
-    <figcaption>Sudan</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="united-arab-emirates"></div>
-    <figcaption>United Arab Emirates</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="libya"></div>
-    <figcaption>Libya</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="mauritius"></div>
-    <figcaption>Mauritius</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="pakistan"></div>
-    <figcaption>Pakistan</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="panama"></div>
-    <figcaption>Panama</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="togo"></div>
-    <figcaption>Togo</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="tonga"></div>
-    <figcaption>Tonga</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="turkey"></div>
-    <figcaption>Turkey</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="uzbekistan"></div>
-    <figcaption>Uzbekistan</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="argentina"></div>
-    <figcaption>Argentina</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="canada"></div>
-    <figcaption>Canada</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="england"></div>
-    <figcaption>England</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="greece"></div>
-    <figcaption>Greece</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="mexico"></div>
-    <figcaption>Mexico</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="myanmar"></div>
-    <figcaption>Myanmar</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="peru"></div>
-    <figcaption>Peru</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="portugal"></div>
-    <figcaption>Portugal</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="scotland"></div>
-    <figcaption>Scotland</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="spain"></div>
-    <figcaption>Spain</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="costa-rica"></div>
-    <figcaption>Costa Rica</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="croatia"></div>
-    <figcaption>Croatia</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="el-salvador"></div>
-    <figcaption>El Salvador</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="equatorial-guinea"></div>
-    <figcaption>Equatorial Guinea</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="guatemala"></div>
-    <figcaption>Guatemala</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="guinea-bissau"></div>
-    <figcaption>Guinea-Bissau</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="lesotho"></div>
-    <figcaption>Lesotho</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="moldova"></div>
-    <figcaption>Moldova</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="nicaragua"></div>
-    <figcaption>Nicaragua</figcaption>
-  </figure>
-  <figure class="flag-card">
-    <div id="paraguay"></div>
-    <figcaption>Paraguay</figcaption>
-  </figure>
   <figure class="flag-card">
     <div id="afghanistan"></div>
     <figcaption>Afghanistan</figcaption>
@@ -738,6 +231,11 @@
   <figure class="flag-card">
     <div id="albania"></div>
     <figcaption>Albania</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="algeria"></div>
+    <figcaption>Algeria</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -751,8 +249,53 @@
   </figure>
 
   <figure class="flag-card">
+    <div id="antigua-and-barbuda"></div>
+    <figcaption>Antigua And Barbuda</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="argentina"></div>
+    <figcaption>Argentina</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="armenia"></div>
+    <figcaption>Armenia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="australia"></div>
+    <figcaption>Australia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="austria"></div>
+    <figcaption>Austria</figcaption>
+  </figure>
+
+  <figure class="flag-card">
     <div id="azerbaijan"></div>
     <figcaption>Azerbaijan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="bahamas"></div>
+    <figcaption>Bahamas</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="bahrain"></div>
+    <figcaption>Bahrain</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="bangladesh"></div>
+    <figcaption>Bangladesh</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="barbados"></div>
+    <figcaption>Barbados</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -761,103 +304,38 @@
   </figure>
 
   <figure class="flag-card">
-    <div id="cambodia"></div>
-    <figcaption>Cambodia</figcaption>
+    <div id="belgium"></div>
+    <figcaption>Belgium</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="cape-verde"></div>
-    <figcaption>Cape Verde</figcaption>
+    <div id="belize"></div>
+    <figcaption>Belize</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="comoros"></div>
-    <figcaption>Comoros</figcaption>
+    <div id="benin"></div>
+    <figcaption>Benin</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="ethiopia"></div>
-    <figcaption>Ethiopia</figcaption>
+    <div id="bhutan"></div>
+    <figcaption>Bhutan</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="georgia"></div>
-    <figcaption>Georgia</figcaption>
+    <div id="bolivia"></div>
+    <figcaption>Bolivia</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="iran"></div>
-    <figcaption>Iran</figcaption>
+    <div id="bosnia-and-herzegovina"></div>
+    <figcaption>Bosnia And Herzegovina</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="iraq"></div>
-    <figcaption>Iraq</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="israel"></div>
-    <figcaption>Israel</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="kenya"></div>
-    <figcaption>Kenya</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="north-korea"></div>
-    <figcaption>North Korea</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="lebanon"></div>
-    <figcaption>Lebanon</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="malawi"></div>
-    <figcaption>Malawi</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="maldives"></div>
-    <figcaption>Maldives</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="oman"></div>
-    <figcaption>Oman</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="philippines"></div>
-    <figcaption>Philippines</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="singapore"></div>
-    <figcaption>Singapore</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="slovenia"></div>
-    <figcaption>Slovenia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="taiwan"></div>
-    <figcaption>Taiwan</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="tajikistan"></div>
-    <figcaption>Tajikistan</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="barbados"></div>
-    <figcaption>Barbados</figcaption>
+    <div id="botswana"></div>
+    <figcaption>Botswana</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -871,13 +349,118 @@
   </figure>
 
   <figure class="flag-card">
+    <div id="bulgaria"></div>
+    <figcaption>Bulgaria</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="burkina-faso"></div>
+    <figcaption>Burkina Faso</figcaption>
+  </figure>
+
+  <figure class="flag-card">
     <div id="burundi"></div>
     <figcaption>Burundi</figcaption>
   </figure>
 
   <figure class="flag-card">
+    <div id="cambodia"></div>
+    <figcaption>Cambodia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="cameroon"></div>
+    <figcaption>Cameroon</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="canada"></div>
+    <figcaption>Canada</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="cape-verde"></div>
+    <figcaption>Cape Verde</figcaption>
+  </figure>
+
+  <figure class="flag-card">
     <div id="central-african-republic"></div>
     <figcaption>Central African Republic</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="chad"></div>
+    <figcaption>Chad</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="chile"></div>
+    <figcaption>Chile</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="china"></div>
+    <figcaption>China</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="colombia"></div>
+    <figcaption>Colombia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="comoros"></div>
+    <figcaption>Comoros</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="congo-drc"></div>
+    <figcaption>Congo Drc</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="congo-republic"></div>
+    <figcaption>Congo Republic</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="costa-rica"></div>
+    <figcaption>Costa Rica</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="croatia"></div>
+    <figcaption>Croatia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="cuba"></div>
+    <figcaption>Cuba</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="cyprus"></div>
+    <figcaption>Cyprus</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="czech-republic"></div>
+    <figcaption>Czech Republic</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="denmark"></div>
+    <figcaption>Denmark</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="djibouti"></div>
+    <figcaption>Djibouti</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="dominica"></div>
+    <figcaption>Dominica</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -891,8 +474,113 @@
   </figure>
 
   <figure class="flag-card">
+    <div id="egypt"></div>
+    <figcaption>Egypt</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="el-salvador"></div>
+    <figcaption>El Salvador</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="england"></div>
+    <figcaption>England</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="equatorial-guinea"></div>
+    <figcaption>Equatorial Guinea</figcaption>
+  </figure>
+
+  <figure class="flag-card">
     <div id="eritrea"></div>
     <figcaption>Eritrea</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="estonia"></div>
+    <figcaption>Estonia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="eswatini"></div>
+    <figcaption>Eswatini</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="ethiopia"></div>
+    <figcaption>Ethiopia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="fiji"></div>
+    <figcaption>Fiji</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="finland"></div>
+    <figcaption>Finland</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="france"></div>
+    <figcaption>France</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="gabon"></div>
+    <figcaption>Gabon</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="gambia"></div>
+    <figcaption>Gambia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="georgia"></div>
+    <figcaption>Georgia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="germany"></div>
+    <figcaption>Germany</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="ghana"></div>
+    <figcaption>Ghana</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="greece"></div>
+    <figcaption>Greece</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="grenada"></div>
+    <figcaption>Grenada</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="guatemala"></div>
+    <figcaption>Guatemala</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="guinea"></div>
+    <figcaption>Guinea</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="guinea-bissau"></div>
+    <figcaption>Guinea Bissau</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="guyana"></div>
+    <figcaption>Guyana</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -901,8 +589,93 @@
   </figure>
 
   <figure class="flag-card">
+    <div id="honduras"></div>
+    <figcaption>Honduras</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="hungary"></div>
+    <figcaption>Hungary</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="iceland"></div>
+    <figcaption>Iceland</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="india"></div>
+    <figcaption>India</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="indonesia"></div>
+    <figcaption>Indonesia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="iran"></div>
+    <figcaption>Iran</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="iraq"></div>
+    <figcaption>Iraq</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="ireland"></div>
+    <figcaption>Ireland</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="israel"></div>
+    <figcaption>Israel</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="italy"></div>
+    <figcaption>Italy</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="ivory-coast"></div>
+    <figcaption>Ivory Coast</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="jamaica"></div>
+    <figcaption>Jamaica</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="japan"></div>
+    <figcaption>Japan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="jordan"></div>
+    <figcaption>Jordan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
     <div id="kazakhstan"></div>
     <figcaption>Kazakhstan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="kenya"></div>
+    <figcaption>Kenya</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="kiribati"></div>
+    <figcaption>Kiribati</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="kuwait"></div>
+    <figcaption>Kuwait</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -911,8 +684,113 @@
   </figure>
 
   <figure class="flag-card">
+    <div id="laos"></div>
+    <figcaption>Laos</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="latvia"></div>
+    <figcaption>Latvia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="lebanon"></div>
+    <figcaption>Lebanon</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="lesotho"></div>
+    <figcaption>Lesotho</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="liberia"></div>
+    <figcaption>Liberia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="libya"></div>
+    <figcaption>Libya</figcaption>
+  </figure>
+
+  <figure class="flag-card">
     <div id="liechtenstein"></div>
     <figcaption>Liechtenstein</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="lithuania"></div>
+    <figcaption>Lithuania</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="luxembourg"></div>
+    <figcaption>Luxembourg</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="madagascar"></div>
+    <figcaption>Madagascar</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="malawi"></div>
+    <figcaption>Malawi</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="malaysia"></div>
+    <figcaption>Malaysia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="maldives"></div>
+    <figcaption>Maldives</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="mali"></div>
+    <figcaption>Mali</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="malta"></div>
+    <figcaption>Malta</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="marshall-islands"></div>
+    <figcaption>Marshall Islands</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="mauritania"></div>
+    <figcaption>Mauritania</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="mauritius"></div>
+    <figcaption>Mauritius</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="mexico"></div>
+    <figcaption>Mexico</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="micronesia"></div>
+    <figcaption>Micronesia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="moldova"></div>
+    <figcaption>Moldova</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="monaco"></div>
+    <figcaption>Monaco</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -926,45 +804,8 @@
   </figure>
 
   <figure class="flag-card">
-    <div id="namibia"></div>
-    <figcaption>Namibia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="nepal"></div>
-  <figure class="flag-card">
-    <div id="zimbabwe"></div>
-    <figcaption>Zimbabwe</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="united-kingdom"></div>
-    <figcaption>United Kingdom</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="vanuatu"></div>
-    <figcaption>Vanuatu</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="solomon-islands"></div>
-    <figcaption>Solomon Islands</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="antigua-and-barbuda"></div>
-    <figcaption>Antigua And Barbuda</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="turkmenistan"></div>
-    <figcaption>Turkmenistan</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="bosnia-and-herzegovina"></div>
-    <figcaption>Bosnia And Herzegovina</figcaption>
+    <div id="morocco"></div>
+    <figcaption>Morocco</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -973,151 +814,28 @@
   </figure>
 
   <figure class="flag-card">
-    <div id="dominica"></div>
-    <figcaption>Dominica</figcaption>
+    <div id="myanmar"></div>
+    <figcaption>Myanmar</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="cyprus"></div>
-    <figcaption>Cyprus</figcaption>
+    <div id="namibia"></div>
+    <figcaption>Namibia</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="kiribati"></div>
-    <figcaption>Kiribati</figcaption>
+    <div id="nauru"></div>
+    <figcaption>Nauru</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="sri-lanka"></div>
-    <figcaption>Sri Lanka</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="timor-leste"></div>
-    <figcaption>Timor Leste</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="eswatini"></div>
-    <figcaption>Eswatini</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="malaysia"></div>
-    <figcaption>Malaysia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="tuvalu"></div>
-    <figcaption>Tuvalu</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="south-africa"></div>
-    <figcaption>South Africa</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="australia"></div>
-    <figcaption>Australia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="saint-kitts-and-nevis"></div>
-    <figcaption>Saint Kitts And Nevis</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="guyana"></div>
-    <figcaption>Guyana</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="venezuela"></div>
-    <figcaption>Venezuela</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="bhutan"></div>
-    <figcaption>Bhutan</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="saudi-arabia"></div>
-    <figcaption>Saudi Arabia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="zambia"></div>
-    <figcaption>Zambia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="uruguay"></div>
-    <figcaption>Uruguay</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="fiji"></div>
-    <figcaption>Fiji</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="sao-tome-and-principe"></div>
-    <figcaption>Sao Tome And Principe</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="malta"></div>
-    <figcaption>Malta</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="mauritania"></div>
-    <figcaption>Mauritania</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="north-macedonia"></div>
-    <figcaption>North Macedonia</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="south-sudan"></div>
-    <figcaption>South Sudan</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="grenada"></div>
-    <figcaption>Grenada</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="papua-new-guinea"></div>
-    <figcaption>Papua New Guinea</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="south-korea"></div>
-    <figcaption>South Korea</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="belize"></div>
-    <figcaption>Belize</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="uganda"></div>
-    <figcaption>Uganda</figcaption>
-  </figure>
-
-  <figure class="flag-card">
-    <div id="samoa"></div>
-    <figcaption>Samoa</figcaption>
-  </figure>
-
+    <div id="nepal"></div>
     <figcaption>Nepal</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="netherlands"></div>
+    <figcaption>Netherlands</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -1126,18 +844,128 @@
   </figure>
 
   <figure class="flag-card">
+    <div id="nicaragua"></div>
+    <figcaption>Nicaragua</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="niger"></div>
+    <figcaption>Niger</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="nigeria"></div>
+    <figcaption>Nigeria</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="north-korea"></div>
+    <figcaption>North Korea</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="north-macedonia"></div>
+    <figcaption>North Macedonia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="norway"></div>
+    <figcaption>Norway</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="oman"></div>
+    <figcaption>Oman</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="pakistan"></div>
+    <figcaption>Pakistan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="palau"></div>
+    <figcaption>Palau</figcaption>
+  </figure>
+
+  <figure class="flag-card">
     <div id="palestine"></div>
     <figcaption>Palestine</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="micronesia"></div>
-    <figcaption>Micronesia</figcaption>
+    <div id="panama"></div>
+    <figcaption>Panama</figcaption>
   </figure>
 
   <figure class="flag-card">
-    <div id="marshall-islands"></div>
-    <figcaption>Marshall Islands</figcaption>
+    <div id="papua-new-guinea"></div>
+    <figcaption>Papua New Guinea</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="paraguay"></div>
+    <figcaption>Paraguay</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="peru"></div>
+    <figcaption>Peru</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="philippines"></div>
+    <figcaption>Philippines</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="poland"></div>
+    <figcaption>Poland</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="portugal"></div>
+    <figcaption>Portugal</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="qatar"></div>
+    <figcaption>Qatar</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="romania"></div>
+    <figcaption>Romania</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="russia"></div>
+    <figcaption>Russia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="rwanda"></div>
+    <figcaption>Rwanda</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="saint-kitts-and-nevis"></div>
+    <figcaption>Saint Kitts And Nevis</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="saint-lucia"></div>
+    <figcaption>Saint Lucia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="saint-vincent-and-the-grenadines"></div>
+    <figcaption>Saint Vincent And The Grenadines</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="samoa"></div>
+    <figcaption>Samoa</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -1146,8 +974,43 @@
   </figure>
 
   <figure class="flag-card">
+    <div id="sao-tome-and-principe"></div>
+    <figcaption>Sao Tome And Principe</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="saudi-arabia"></div>
+    <figcaption>Saudi Arabia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="scotland"></div>
+    <figcaption>Scotland</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="senegal"></div>
+    <figcaption>Senegal</figcaption>
+  </figure>
+
+  <figure class="flag-card">
     <div id="serbia"></div>
     <figcaption>Serbia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="seychelles"></div>
+    <figcaption>Seychelles</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="sierra-leone"></div>
+    <figcaption>Sierra Leone</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="singapore"></div>
+    <figcaption>Singapore</figcaption>
   </figure>
 
   <figure class="flag-card">
@@ -1155,7 +1018,196 @@
     <figcaption>Slovakia</figcaption>
   </figure>
 
+  <figure class="flag-card">
+    <div id="slovenia"></div>
+    <figcaption>Slovenia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="solomon-islands"></div>
+    <figcaption>Solomon Islands</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="somalia"></div>
+    <figcaption>Somalia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="south-africa"></div>
+    <figcaption>South Africa</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="south-korea"></div>
+    <figcaption>South Korea</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="south-sudan"></div>
+    <figcaption>South Sudan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="spain"></div>
+    <figcaption>Spain</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="sri-lanka"></div>
+    <figcaption>Sri Lanka</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="sudan"></div>
+    <figcaption>Sudan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="suriname"></div>
+    <figcaption>Suriname</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="sweden"></div>
+    <figcaption>Sweden</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="switzerland"></div>
+    <figcaption>Switzerland</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="syria"></div>
+    <figcaption>Syria</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="taiwan"></div>
+    <figcaption>Taiwan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="tajikistan"></div>
+    <figcaption>Tajikistan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="tanzania"></div>
+    <figcaption>Tanzania</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="thailand"></div>
+    <figcaption>Thailand</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="timor-leste"></div>
+    <figcaption>Timor Leste</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="togo"></div>
+    <figcaption>Togo</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="tonga"></div>
+    <figcaption>Tonga</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="trinidad-and-tobago"></div>
+    <figcaption>Trinidad And Tobago</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="tunisia"></div>
+    <figcaption>Tunisia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="turkey"></div>
+    <figcaption>Turkey</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="turkmenistan"></div>
+    <figcaption>Turkmenistan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="tuvalu"></div>
+    <figcaption>Tuvalu</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="uganda"></div>
+    <figcaption>Uganda</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="ukraine"></div>
+    <figcaption>Ukraine</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="united-arab-emirates"></div>
+    <figcaption>United Arab Emirates</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="united-kingdom"></div>
+    <figcaption>United Kingdom</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="uruguay"></div>
+    <figcaption>Uruguay</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="usa"></div>
+    <figcaption>Usa</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="uzbekistan"></div>
+    <figcaption>Uzbekistan</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="vanuatu"></div>
+    <figcaption>Vanuatu</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="venezuela"></div>
+    <figcaption>Venezuela</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="vietnam"></div>
+    <figcaption>Vietnam</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="yemen"></div>
+    <figcaption>Yemen</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="zambia"></div>
+    <figcaption>Zambia</figcaption>
+  </figure>
+
+  <figure class="flag-card">
+    <div id="zimbabwe"></div>
+    <figcaption>Zimbabwe</figcaption>
+  </figure>
+
 </section>
 </body>
 </html>
-

--- a/scripts/sort_index.py
+++ b/scripts/sort_index.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+INDEX_PATH = Path('index.html')
+
+STYLE_BLOCK = """  <style>
+    body {
+      font-family: sans-serif;
+      margin: 2rem;
+    }
+    h1 {
+      text-align: center;
+    }
+    #flags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+    div {
+      border: 1px solid black;
+    }
+  </style>"""
+
+def format_caption(name: str) -> str:
+    return " ".join(word.capitalize() for word in name.split('-'))
+
+
+def main():
+    flags = sorted(p.stem for p in Path('.').glob('*.css'))
+
+    head_parts = [
+        "<!DOCTYPE html>",
+        "<html lang=\"en\">",
+        "<head>",
+        "  <meta charset=\"UTF-8\">",
+        "  <title>Flags of the World</title>",
+    ]
+    head_parts.extend(f"  <link rel=\"stylesheet\" href=\"{flag}.css\">" for flag in flags)
+    head_parts.append(STYLE_BLOCK)
+    head_parts.append("</head>")
+
+    body_parts = ["", "<body>", "", "<section id=\"flags\">", ""]
+    for flag in flags:
+        caption = format_caption(flag)
+        body_parts.extend([
+            "  <figure class=\"flag-card\">",
+            f"    <div id=\"{flag}\"></div>",
+            f"    <figcaption>{caption}</figcaption>",
+            "  </figure>",
+            "",
+        ])
+    body_parts.extend(["</section>", "</body>", "</html>", ""])
+
+    content = "\n".join(head_parts + body_parts)
+    INDEX_PATH.write_text(content)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ensure `index.html` lists all flag stylesheets and figures in alphabetical order
- add helper script to rebuild the page from CSS files

## Testing
- `python scripts/sort_index.py`
- `python -m py_compile scripts/sort_index.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcabc98ec08328b7a9fc03f977674c