### PR TITLE
Add 10 fictional flag CSS entries and update index/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A showcase of national flags rendered with pure CSS.
 
-Currently, **198** flags are included.
+Currently, **208** flags are included.
 
 ## Completed
 
@@ -204,3 +204,13 @@ Currently, **198** flags are included.
 * [Yemen](https://en.wikipedia.org/wiki/Flag_of_Yemen)
 * [Zambia](https://en.wikipedia.org/wiki/Flag_of_Zambia)
 * [Zimbabwe](https://en.wikipedia.org/wiki/Flag_of_Zimbabwe)
+* [Atlantis](#)
+* [Elbonia](#)
+* [Genovia](#)
+* [Gondor](#)
+* [Latveria](#)
+* [Narnia](#)
+* [Panem](#)
+* [Ruritania](#)
+* [Wakanda](#)
+* [Westeros](#)

--- a/fictional/atlantis.css
+++ b/fictional/atlantis.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#atlantis {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(180deg, #0077be 0% 33.333%, #00aaff 33.333% 66.666%, #ffffff 66.666% 100%);
+}

--- a/fictional/elbonia.css
+++ b/fictional/elbonia.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#elbonia {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(180deg, #556b2f 0% 33.333%, #c2b280 33.333% 66.666%, #8b4513 66.666% 100%);
+}

--- a/fictional/genovia.css
+++ b/fictional/genovia.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#genovia {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(90deg, #1b5e20 0% 33.333%, #ffffff 33.333% 66.666%, #b71c1c 66.666% 100%);
+}

--- a/fictional/gondor.css
+++ b/fictional/gondor.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#gondor {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(180deg, #111111 0% 33.333%, #ffffff 33.333% 66.666%, #111111 66.666% 100%);
+}

--- a/fictional/latveria.css
+++ b/fictional/latveria.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#latveria {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(90deg, #1a237e 0% 33.333%, #fdd835 33.333% 66.666%, #1a237e 66.666% 100%);
+}

--- a/fictional/narnia.css
+++ b/fictional/narnia.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#narnia {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(180deg, #0d47a1 0% 33.333%, #ffffff 33.333% 66.666%, #c62828 66.666% 100%);
+}

--- a/fictional/panem.css
+++ b/fictional/panem.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#panem {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(180deg, #212121 0% 33.333%, #f9a825 33.333% 66.666%, #212121 66.666% 100%);
+}

--- a/fictional/ruritania.css
+++ b/fictional/ruritania.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#ruritania {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(90deg, #004d40 0% 33.333%, #ffffff 33.333% 66.666%, #bf360c 66.666% 100%);
+}

--- a/fictional/wakanda.css
+++ b/fictional/wakanda.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#wakanda {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(180deg, #4a148c 0% 33.333%, #000000 33.333% 66.666%, #6a1b9a 66.666% 100%);
+}

--- a/fictional/westeros.css
+++ b/fictional/westeros.css
@@ -1,0 +1,13 @@
+/* reference: Fictional flag created for project showcase */
+
+:root {
+  --flag-height: 2;
+  --flag-width: 3;
+}
+
+#westeros {
+  position: relative;
+  height: 180px;
+  aspect-ratio: var(--flag-width) / var(--flag-height);
+  background: linear-gradient(180deg, #37474f 0% 33.333%, #eceff1 33.333% 66.666%, #263238 66.666% 100%);
+}

--- a/index.html
+++ b/index.html
@@ -192,6 +192,16 @@
   <link rel="stylesheet" href="europe/ukraine.css">
   <link rel="stylesheet" href="asia/united-arab-emirates.css">
   <link rel="stylesheet" href="fictional/united-federation-of-planets.css">
+  <link rel="stylesheet" href="fictional/atlantis.css">
+  <link rel="stylesheet" href="fictional/elbonia.css">
+  <link rel="stylesheet" href="fictional/genovia.css">
+  <link rel="stylesheet" href="fictional/gondor.css">
+  <link rel="stylesheet" href="fictional/latveria.css">
+  <link rel="stylesheet" href="fictional/narnia.css">
+  <link rel="stylesheet" href="fictional/panem.css">
+  <link rel="stylesheet" href="fictional/ruritania.css">
+  <link rel="stylesheet" href="fictional/wakanda.css">
+  <link rel="stylesheet" href="fictional/westeros.css">
   <link rel="stylesheet" href="europe/united-kingdom.css">
   <link rel="stylesheet" href="south-america/uruguay.css">
   <link rel="stylesheet" href="north-america/usa.css">
@@ -1217,6 +1227,56 @@
       <figcaption>Zimbabwe</figcaption>
     </figure>
 
+
+    <figure class="flag-card">
+      <div id="atlantis"></div>
+      <figcaption>Atlantis</figcaption>
+    </figure>
+
+    <figure class="flag-card">
+      <div id="elbonia"></div>
+      <figcaption>Elbonia</figcaption>
+    </figure>
+
+    <figure class="flag-card">
+      <div id="genovia"></div>
+      <figcaption>Genovia</figcaption>
+    </figure>
+
+    <figure class="flag-card">
+      <div id="gondor"></div>
+      <figcaption>Gondor</figcaption>
+    </figure>
+
+    <figure class="flag-card">
+      <div id="latveria"></div>
+      <figcaption>Latveria</figcaption>
+    </figure>
+
+    <figure class="flag-card">
+      <div id="narnia"></div>
+      <figcaption>Narnia</figcaption>
+    </figure>
+
+    <figure class="flag-card">
+      <div id="panem"></div>
+      <figcaption>Panem</figcaption>
+    </figure>
+
+    <figure class="flag-card">
+      <div id="ruritania"></div>
+      <figcaption>Ruritania</figcaption>
+    </figure>
+
+    <figure class="flag-card">
+      <div id="wakanda"></div>
+      <figcaption>Wakanda</figcaption>
+    </figure>
+
+    <figure class="flag-card">
+      <div id="westeros"></div>
+      <figcaption>Westeros</figcaption>
+    </figure>
   </section>
 
 </body>


### PR DESCRIPTION
### Motivation

- Expand the showcase with additional fictional flags to demonstrate the tricolor layout patterns and project conventions.
- Keep the site index and README in sync with newly added flag assets so the gallery and documentation reflect the current set.

### Description

- Added 10 new CSS files under `fictional/` (`atlantis`, `elbonia`, `genovia`, `gondor`, `latveria`, `narnia`, `panem`, `ruritania`, `wakanda`, `westeros`) implementing simple three-band designs using the existing `--flag-height`/`--flag-width` conventions and `#id` selectors for each flag.
- Updated `index.html` to include `<link rel="stylesheet">` entries for each new fictional CSS file.
- Inserted corresponding `<figure class="flag-card">` blocks with `<div id="...">` and `<figcaption>` for each new flag into the flags gallery in `index.html`.
- Updated `README.md` to increment the total flags count from `**198**` to `**208**` and appended the 10 new fictional entries to the completed list.

### Testing

- Ran `python -m py_compile scripts/*.py` to ensure Python scripts still compile successfully, and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f671ee7f088328b2b8339b92400fb7)