### PR TITLE
Refactor flag designs using clip-path and conic-gradient

### DIFF
--- a/asia/oman.css
+++ b/asia/oman.css
@@ -8,25 +8,29 @@
   --oman-white: #FFFFFF;
 }
 
+/* Fly: three horizontal bands of white, red and green */
 #oman {
   position: relative;
   height: 180px;
   aspect-ratio: var(--flag-width) / var(--flag-height);
   background: linear-gradient(
     180deg,
-    var(--oman-red) 0%,
-    var(--oman-red) 50%,
-    var(--oman-green) 50%,
+    var(--oman-white) 0%,
+    var(--oman-white) 33.333%,
+    var(--oman-red) 33.333%,
+    var(--oman-red) 66.666%,
+    var(--oman-green) 66.666%,
     var(--oman-green) 100%
   );
 }
 
+/* Vertical red band along the hoist */
 #oman::before {
   content: "";
   position: absolute;
   top: 0;
   bottom: 0;
   left: 0;
-  width: 33%;
-  background: var(--oman-white);
+  width: 28%;
+  background: var(--oman-red);
 }

--- a/europe/scotland.css
+++ b/europe/scotland.css
@@ -15,34 +15,16 @@
   overflow: hidden;
 }
 
-#scotland::before,
-#scotland::after {
+/* White saltire (St Andrew's Cross) reaching corner to corner */
+#scotland::before {
   content: "";
   position: absolute;
-  width: 100%;
-  height: 100%;
-}
-
-#scotland::before {
-  background: linear-gradient(
-    to bottom right,
-    var(--scotland-white) 0%,
-    var(--scotland-white) 15%,
-    transparent 15%,
-    transparent 85%,
-    var(--scotland-white) 85%,
-    var(--scotland-white) 100%
-  );
-}
-
-#scotland::after {
-  background: linear-gradient(
-    to top right,
-    var(--scotland-white) 0%,
-    var(--scotland-white) 15%,
-    transparent 15%,
-    transparent 85%,
-    var(--scotland-white) 85%,
-    var(--scotland-white) 100%
+  inset: 0;
+  background: var(--scotland-white);
+  clip-path: polygon(
+    0 0, 12% 0, 50% 38%, 88% 0, 100% 0,
+    100% 12%, 62% 50%, 100% 88%, 100% 100%,
+    88% 100%, 50% 62%, 12% 100%, 0 100%,
+    0 88%, 38% 50%, 0 12%
   );
 }

--- a/north-america/dominican-republic.css
+++ b/north-america/dominican-republic.css
@@ -12,11 +12,13 @@
   position: relative;
   height: 180px;
   aspect-ratio: var(--flag-width) / var(--flag-height);
-  background: linear-gradient(180deg,
-      var(--dr-blue) 0%,
-      var(--dr-blue) 50%,
-      var(--dr-red) 50%,
-      var(--dr-red) 100%
+  /* Four quarters: hoist-top blue, fly-top red, hoist-bottom red, fly-bottom blue */
+  background: conic-gradient(
+      from 0deg at 50% 50%,
+      var(--dr-red) 0deg 90deg,
+      var(--dr-blue) 90deg 180deg,
+      var(--dr-red) 180deg 270deg,
+      var(--dr-blue) 270deg 360deg
     );
 }
 

--- a/north-america/jamaica.css
+++ b/north-america/jamaica.css
@@ -4,27 +4,37 @@
   --flag-height: 1;
   --flag-width: 2;
   --jamaica-green: #009b3a;
-  --jamaica_black: #000000;
-  --jamaica_yellow: #fed100;
+  --jamaica-black: #000000;
+  --jamaica-yellow: #fed100;
 }
 
+/* Green fills the top and bottom triangles */
 #jamaica {
   position: relative;
   height: 180px;
   aspect-ratio: var(--flag-width) / var(--flag-height);
-  background:
-    linear-gradient(45deg, var(--jamaica_black) 0%, var(--jamaica_black) 50%, var(--jamaica_green) 50%, var(--jamaica_green) 100%),
-    linear-gradient(-45deg, var(--jamaica_black) 0%, var(--jamaica_black) 50%, var(--jamaica_green) 50%, var(--jamaica_green) 100%);
-  background-size: 100% 100%, 100% 100%;
+  background: var(--jamaica-green);
 }
 
+/* Black hoist and fly triangles */
 #jamaica::before {
   content: "";
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(45deg, transparent 0%, transparent 45%, var(--jamaica_yellow) 45%, var(--jamaica_yellow) 55%, transparent 55%, transparent 100%),
-              linear-gradient(-45deg, transparent 0%, transparent 45%, var(--jamaica_yellow) 45%, var(--jamaica_yellow) 55%, transparent 55%, transparent 100%);
+  inset: 0;
+  background: var(--jamaica-black);
+  clip-path: polygon(0 0, 50% 50%, 0 100%, 100% 100%, 50% 50%, 100% 0);
+}
+
+/* Gold saltire (diagonal cross) reaching corner to corner */
+#jamaica::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--jamaica-yellow);
+  clip-path: polygon(
+    0 0, 9.3% 0, 50% 40.7%, 90.7% 0, 100% 0,
+    100% 9.3%, 59.3% 50%, 100% 90.7%, 100% 100%,
+    90.7% 100%, 50% 59.3%, 9.3% 100%, 0 100%,
+    0 90.7%, 40.7% 50%, 0 9.3%
+  );
 }

--- a/north-america/panama.css
+++ b/north-america/panama.css
@@ -12,10 +12,14 @@
   position: relative;
   height: 180px;
   aspect-ratio: var(--flag-width) / var(--flag-height);
-  background:
-    linear-gradient(90deg, var(--panama-white) 0%, var(--panama-white) 50%, var(--panama-red) 50%, var(--panama-red) 100%),
-    linear-gradient(180deg, var(--panama-blue) 0%, var(--panama-blue) 50%, var(--panama-white) 50%, var(--panama-white) 100%);
-  background-size: 100% 50%, 100% 100%;
+  /* Four quarters: hoist-top white, fly-top red, hoist-bottom blue, fly-bottom white */
+  background: conic-gradient(
+    from 0deg at 50% 50%,
+    var(--panama-red) 0deg 90deg,
+    var(--panama-white) 90deg 180deg,
+    var(--panama-blue) 180deg 270deg,
+    var(--panama-white) 270deg 360deg
+  );
 }
 
 #panama::before,

--- a/oceania/new-zealand.css
+++ b/oceania/new-zealand.css
@@ -1,28 +1,8 @@
 /* reference: https://en.wikipedia.org/wiki/Flag_of_New_Zealand */
 
-:root {
-  --flag-height: 1;
-  --flag-width: 2;
-  --nz-blue: #00247d;
-  --nz-red: #cc142b;
-  --nz-white: #ffffff;
-}
-
 #new-zealand {
-  position: relative;
   height: 180px;
-  aspect-ratio: var(--flag-width) / var(--flag-height);
-  background: var(--nz-blue);
-}
-
-#new-zealand::before {
-  content: "";
-  position: absolute;
-  top: 20%;
-  left: 60%;
-  width: 15%;
-  height: 15%;
-  background: var(--nz-red);
-  border: 3px solid var(--nz-white);
-  border-radius: 50%;
+  aspect-ratio: 1280/640;
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTI4MCIgaGVpZ2h0PSI2NDAiIHZpZXdCb3g9IjAgMCAxMDA4MCA1MDQwIj48ZGVmcz48Y2xpcFBhdGggaWQ9ImEiPjxwYXRoIGQ9Ik0wIDBoNnYzSDB6Ii8+PC9jbGlwUGF0aD48Y2xpcFBhdGggaWQ9ImIiPjxwYXRoIGQ9Ik0wIDB2MS41aDZWM3ptNiAwSDN2M0gweiIvPjwvY2xpcFBhdGg+PHBhdGggaWQ9InMiIGQ9Ik0wLTEgLjIyNDUtLjMwOSAuOTUxMS0uMzA5IC4zNjMzIC4xMTggLjU4NzggLjgwOSAwIC4zODItLjU4NzggLjgwOS0uMzYzMyAuMTE4LS45NTExLS4zMDktLjIyNDUtLjMwOXoiLz48L2RlZnM+PHBhdGggZmlsbD0iIzAwMjQ3ZCIgZD0iTTAgMGgxMDA4MHY1MDQwSDB6Ii8+PHBhdGggZD0ibTAgMCA2IDNtMC0zTDAgMyIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9Ii42IiBjbGlwLXBhdGg9InVybCgjYSkiIHRyYW5zZm9ybT0ic2NhbGUoODQwKSIvPjxwYXRoIGQ9Im0wIDAgNiAzbTAtM0wwIDMiIHN0cm9rZT0iI2NjMTQyYiIgc3Ryb2tlLXdpZHRoPSIuNCIgY2xpcC1wYXRoPSJ1cmwoI2IpIiB0cmFuc2Zvcm09InNjYWxlKDg0MCkiLz48cGF0aCBkPSJNMjUyMCAwdjI1MjBNMCAxMjYwaDUwNDAiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSI4NDAiLz48cGF0aCBkPSJNMjUyMCAwdjI1MjBNMCAxMjYwaDUwNDAiIHN0cm9rZT0iI2NjMTQyYiIgc3Ryb2tlLXdpZHRoPSI1MDQiLz48Zz48dXNlIHhsaW5rOmhyZWY9IiNzIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg3NTYwIDg0MCkgc2NhbGUoMzYwKSIgZmlsbD0iI2ZmZiIvPjx1c2UgeGxpbms6aHJlZj0iI3MiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDg2ODAgMTg2OSkgc2NhbGUoMzYwKSIgZmlsbD0iI2ZmZiIvPjx1c2UgeGxpbms6aHJlZj0iI3MiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDYzMDAgMjIwNSkgc2NhbGUoMzYwKSIgZmlsbD0iI2ZmZiIvPjx1c2UgeGxpbms6aHJlZj0iI3MiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDc1NjAgNDIwMCkgc2NhbGUoNDE1KSIgZmlsbD0iI2ZmZiIvPjx1c2UgeGxpbms6aHJlZj0iI3MiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDc1NjAgODQwKSBzY2FsZSgyODApIiBmaWxsPSIjY2MxNDJiIi8+PHVzZSB4bGluazpocmVmPSIjcyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoODY4MCAxODY5KSBzY2FsZSgyODApIiBmaWxsPSIjY2MxNDJiIi8+PHVzZSB4bGluazpocmVmPSIjcyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNjMwMCAyMjA1KSBzY2FsZSgyODApIiBmaWxsPSIjY2MxNDJiIi8+PHVzZSB4bGluazpocmVmPSIjcyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNzU2MCA0MjAwKSBzY2FsZSgzMzApIiBmaWxsPSIjY2MxNDJiIi8+PC9nPjwvc3ZnPgo=');
+  background-size: 100% 100%;
 }


### PR DESCRIPTION
## Summary
This PR modernizes the flag CSS implementations by replacing complex linear gradient combinations with more efficient and maintainable approaches using `clip-path` polygons and `conic-gradient`.

## Key Changes

- **Scotland**: Replaced dual pseudo-element linear gradients with a single `::before` using `clip-path` polygon to create the white saltire (St Andrew's Cross)

- **Jamaica**: 
  - Fixed CSS variable naming inconsistency (`--jamaica_black` → `--jamaica-black`, `--jamaica_yellow` → `--jamaica-yellow`)
  - Simplified background from overlapping gradients to base green color
  - Refactored black triangles using `clip-path` on `::before`
  - Added `::after` pseudo-element with `clip-path` for the gold saltire

- **New Zealand**: Replaced CSS-based design with an embedded SVG data URI for accurate flag representation

- **Oman**: 
  - Corrected band order (white-red-green instead of red-green)
  - Changed `::before` from white vertical band to red vertical band with adjusted width (28%)

- **Dominican Republic**: Replaced linear gradients with `conic-gradient` to create the four-quarter quartered design

- **Panama**: Replaced stacked linear gradients with `conic-gradient` for cleaner four-quarter implementation

## Implementation Details

- Used `inset: 0` shorthand instead of explicit `top/left/width/height` properties
- Leveraged `clip-path` polygon coordinates for precise geometric shapes (saltires, triangles)
- Applied `conic-gradient` for radial quarter divisions, improving readability and maintainability
- Maintained visual accuracy while reducing CSS complexity

https://claude.ai/code/session_012eZBSGu6ZX1K6XrciQanCe